### PR TITLE
fix: Display Plain Text for Card Content in Collection List

### DIFF
--- a/frontend/src/routes/_layout/collections/$collectionId/cards/new.tsx
+++ b/frontend/src/routes/_layout/collections/$collectionId/cards/new.tsx
@@ -20,8 +20,8 @@ function NewCard() {
   const handleClose = async () => {
     await saveCard({
       ...card,
-      front: frontEditor?.storage.markdown.getMarkdown() || '',
-      back: backEditor?.storage.markdown.getMarkdown() || '',
+      front: frontEditor?.getHTML() || '',
+      back: backEditor?.getHTML() || '',
     })
     navigate({ to: `/collections/${collectionId}` })
   }


### PR DESCRIPTION
Fixes #54.

Based on observations of the issue, it appeared to stem from a disparity between the saving process for creating and updating. If a new file was saved, the markdown symbols were shown in the preview. If a file was updated, even if nothing was changed to the rich text, the preview correctly showed as plain text. Investigating the indexedDB revealed that the stored string differed between the initial save and an update, even if the update appeared to do nothing to the card. This could be traced back to the calling of the function `saveCard`. Thus, by replacing the call to `editor?.storage.markdown.getMarkdown()` with a call to `editor?.getHTML()`, as it was done in `updateCard`, the creation of a new card is now in line with the update of a card, which fixes the issue of a preview containing markdown characters. Since the change happens at a point before the retrieval of the selected repository through `repo()`, this change will fix it for both the offline database (indexedDB) as well as the online database (backend + postgre).

With the fix, the collection's card preview now aligns with the expected behavior as specified in #54:
- Card content in the collection list is shown as plain text, with all markdown tags and formatting removed or ignored.
- The preview is clean, readable, and free of markdown syntax.