### PR TITLE
Fix: Fix Code Block Styles in Editor (Light Mode)

### DIFF
--- a/frontend/src/components/commonUI/RichText/RichText.styles.css
+++ b/frontend/src/components/commonUI/RichText/RichText.styles.css
@@ -86,6 +86,7 @@
 .tiptap-editor code,
 .tiptap-content code {
   background-color: var(--chakra-colors-bg-code);
+  color: var(--chakra-colors-fg-code);
   border-radius: 0.25rem;
   padding: 0.2em 0.4em;
   font-family: "Menlo", "Monaco", "Courier New", monospace;
@@ -95,7 +96,7 @@
 .tiptap-editor pre,
 .tiptap-content pre {
   background-color: var(--chakra-colors-bg-code);
-  color: #d4d4d4;
+  color: var(--chakra-colors-fg-code);
   padding: 0.75em 1em;
   border-radius: 0.375rem;
   font-family: "Menlo", "Monaco", "Courier New", monospace;

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -26,7 +26,7 @@ const config = defineConfig({
             value: { _light: '#F4F4F5', _dark: '#24292E' },
           },
           code: {
-            value: { _light: '#f0f0f3', _dark: '#202429' },
+            value: { _light: '#e4e4e7', _dark: '#202429' },
           },
         },
         fg: {
@@ -38,6 +38,9 @@ const config = defineConfig({
           },
           muted: {
             value: { _light: '{colors.gray.600}', _dark: '{colors.gray.400}' },
+          },
+          code: {
+            value: { _light: '{colors.gray.700}', _dark: '{colors.gray.300}' },
           },
         },
         fbuttons: {


### PR DESCRIPTION
Fixes #40 Code Blocks in the card editor displayed incorrect text colors.

### Changes

#### `frontend/src/theme.tsx`
- Adjusted the `code` background token for light mode from `#f0f0f3` to `#e4e4e7` (same color as menu bar) for a slightly stronger contrast against the page background.
- Added a new semantic `fg.code` color token:
  - `_light: '{colors.gray.700}'` — dark enough to be legible on a light background
  - `_dark: '{colors.gray.300}'` — unchanged soft tone for dark mode

#### `frontend/src/components/commonUI/RichText/RichText.styles.css`
- Replaced the hardcoded `color: #d4d4d4` on `pre` blocks (a light gray that was invisible in light mode) with `color: var(--chakra-colors-fg-code)`, which now correctly resolves per theme.
- Added the same `color: var(--chakra-colors-fg-code)` to inline `code` elements, which previously had no explicit foreground color at all.

<img width="919" height="412" alt="Schermafbeelding 2026-03-22 182448" src="https://github.com/user-attachments/assets/c8038b50-1151-4119-96bc-f2e2635186f4" />

### Root cause

The `pre` block had a hardcoded color (`#d4d4d4`) that only worked in dark mode. In light mode this rendered near-white text on a light background, making code essentially invisible. Inline `code` blocks had no foreground color set at all, so they also fell through to an unreadable default.